### PR TITLE
Rename sheet in generated xlsx template

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -18,6 +18,8 @@ def create_renderer_templates():
     xlsx_template_dir = f'{pkg_slug}/{report_slug}/templates/xlsx'
     os.makedirs(xlsx_template_dir)
     wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Data"
     wb.save(f'{xlsx_template_dir}/template.xlsx')
 
     # PDF


### PR DESCRIPTION
This commit changes the post_gen_project hook to generate an Excel
template which will not cause "Worksheet Data does not exist" when
executed.

Closes cloudblue/connect-report-python-boilerplate#12